### PR TITLE
Apply new network configs directory structure

### DIFF
--- a/src/network/bootnodes.go
+++ b/src/network/bootnodes.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const BootNodeLocation = "https://raw.githubusercontent.com/lukso-network/network-configs/main/%s/%s/%s"
+const BootNodeLocation = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/%s/%s"
 
 type Bootnode struct {
 	Consensus string `json:"consensus"`

--- a/src/network/node_params.go
+++ b/src/network/node_params.go
@@ -6,7 +6,7 @@ import (
 )
 
 const NodeParamsDevLocation = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/%s"
-const NodeParamsLocation = "https://raw.githubusercontent.com/lukso-network/network-configs/main/%s/%s"
+const NodeParamsLocation = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/%s"
 
 type NodeParams struct {
 	ExecutionAPI   string `json:"executionApi"`

--- a/src/network/node_params.go
+++ b/src/network/node_params.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const NodeParamsDevLocation = "https://raw.githubusercontent.com/lukso-network/network-configs/main/dev/%s/%s"
+const NodeParamsDevLocation = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/%s"
 const NodeParamsLocation = "https://raw.githubusercontent.com/lukso-network/network-configs/main/%s/%s"
 
 type NodeParams struct {

--- a/src/network/resource_downloader.go
+++ b/src/network/resource_downloader.go
@@ -12,8 +12,8 @@ const (
 	DockerComposeDefaultName = "docker-compose.yml"
 	DockerGitLocation        = "https://raw.githubusercontent.com/lukso-network/network-configs/main/%s/docker/docker-compose.%s.yml"
 	ConfigGitLocation        = "https://raw.githubusercontent.com/lukso-network/network-configs/main/%s/configs"
-	DevDockerGitLocation     = "https://raw.githubusercontent.com/lukso-network/network-configs/main/dev/%s/docker/docker-compose.%s.yml"
-	DevConfigGitLocation     = "https://raw.githubusercontent.com/lukso-network/network-configs/main/dev/%s/configs"
+	DevDockerGitLocation     = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/docker/docker-compose.%s.yml"
+	DevConfigGitLocation     = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/configs"
 )
 
 type ResourceDownloader struct {

--- a/src/network/resource_downloader.go
+++ b/src/network/resource_downloader.go
@@ -10,8 +10,8 @@ const (
 	BeaconClientPrysm = "prysm"
 
 	DockerComposeDefaultName = "docker-compose.yml"
-	DockerGitLocation        = "https://raw.githubusercontent.com/lukso-network/network-configs/main/%s/docker/docker-compose.%s.yml"
-	ConfigGitLocation        = "https://raw.githubusercontent.com/lukso-network/network-configs/main/%s/configs"
+	DockerGitLocation        = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/docker/docker-compose.%s.yml"
+	ConfigGitLocation        = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/configs"
 	DevDockerGitLocation     = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/docker/docker-compose.%s.yml"
 	DevConfigGitLocation     = "https://raw.githubusercontent.com/lukso-network/network-configs/main/devnets/%s/configs"
 )


### PR DESCRIPTION
We have created new directory structure in `network-configs` repository, so we need to adapt those changes to `lukso-cli` too. Community reported issues with current `lukso-cli` release:
![image](https://user-images.githubusercontent.com/19270807/225894611-28e83254-1563-4ebe-8f3c-91cfee3686d4.png)
